### PR TITLE
Upgrade rest-client, webmock, and fix spec errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,15 @@
 PATH
   remote: .
   specs:
-    passaporteweb-client (0.4.0)
+    passaporteweb-client (0.4.1)
       multi_json (~> 1.11)
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0, >= 2.0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.5.1)
-      public_suffix (~> 2.0, >= 2.0.2)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     awesome_print (1.8.0)
     byebug (9.0.6)
     coderay (1.1.1)
@@ -25,12 +25,15 @@ GEM
     docile (1.1.5)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
+    hashdiff (0.3.7)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     json (2.1.0)
     method_source (0.8.2)
-    mime-types (2.99.3)
-    multi_json (1.12.1)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    multi_json (1.12.2)
     netrc (0.11.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -39,13 +42,13 @@ GEM
     pry-byebug (3.4.2)
       byebug (~> 9.0)
       pry (~> 0.10)
-    public_suffix (2.0.5)
+    public_suffix (3.0.1)
     rake (12.0.0)
     rdoc (5.1.0)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
       rspec-expectations (~> 3.6.0)
@@ -74,9 +77,10 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     vcr (2.9.3)
-    webmock (1.9.3)
-      addressable (>= 2.2.7)
+    webmock (3.1.1)
+      addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -93,7 +97,7 @@ DEPENDENCIES
   rspec (~> 3.6)
   simplecov (~> 0.14)
   vcr (~> 2.4)
-  webmock (~> 1.9.3)
+  webmock (~> 3.1.0, >= 3.1.1)
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/lib/passaporte_web/version.rb
+++ b/lib/passaporte_web/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module PassaporteWeb
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/passaporteweb-client.gemspec
+++ b/passaporteweb-client.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Ruby client for the PassaporteWeb REST API}
   spec.summary       = %q{A Ruby client for the PassaporteWeb REST API: https://app.passaporteweb.com.br/static/docs/}
   spec.homepage      = "https://github.com/myfreecomm/passaporteweb-client-ruby"
-  spec.license       = "Apache-v2"
+  spec.license       = "Apache-2.0"
   spec.has_rdoc      = true
 
   # VCR cassettes are too long for the gemspec, see http://stackoverflow.com/questions/14371686/building-rails-3-engine-throwing-gempackagetoolongfilename-error
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rest-client", "~> 1.8.0"
+  spec.add_dependency 'rest-client', '~> 2.0', '>= 2.0.2'
   spec.add_dependency "multi_json", "~> 1.11"
 
   spec.add_development_dependency "bundler", "~> 1.9"
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rdoc", "~> 5.1"
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "vcr", "~> 2.4"
-  spec.add_development_dependency "webmock", "~> 1.9.3"
+  spec.add_development_dependency 'webmock', '~> 3.1.0', '>= 3.1.1'
   spec.add_development_dependency "pry-byebug", "~> 3.4"
   spec.add_development_dependency "awesome_print", "~> 1.8"
   spec.add_development_dependency "simplecov", "~> 0.14"

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_raise_an_error_if_the_email_is_not_set.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_raise_an_error_if_the_email_is_not_set.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_an_instance_of_Identity_if_the_password_is_correct_for_the_given_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_an_instance_of_Identity_if_the_password_is_correct_for_the_given_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://teste%40teste.com:123456@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -75,6 +75,6 @@ http_interactions:
         lsIC/Q2jQO/DqlGTZe71HoIwBs34GRdhpER9UdzirdxywLsEu4WTiTaMl0ba
         9yCoC7JOwf0P5YxIGG+L5JdhGG1ANH4YrjF2eYzhJ4yOgrzr4uLiCgegyYvk
         bPB1eu/zKXX6BlBr+M03AgAA
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:07:27 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_no_Identity_exists_on_PassaporteWeb_with_that_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_no_Identity_exists_on_PassaporteWeb_with_that_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://non_existing_email%40teste.com:some%20password@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:11:13 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_the_password_is_wrong.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_the_password_is_wrong.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -70,11 +70,11 @@ http_interactions:
         vIGnPFzcyT/RVGAow24prWPsQ3vCYaJpaPt4O17c0p8NWJPbrEVr4HDGw0Um
         C+1wd+HpKeAU2xm5fZ7lr0x5QsxxXGfJfwzHu7m6+nI8fotxoNe0xp7McHmY
         PrdzFhcV8Ih5yWUib+LPy/Mnkqoe/gX4cNFa0AwAAA==
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:03:41 GMT
 - request:
     method: get
-    uri: http://teste%40teste.com:wrong%20password@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -115,6 +115,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:03:43 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_the_password_is_wrong_for_the_given_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_false_if_the_password_is_wrong_for_the_given_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://teste%40teste.com:wrong%20password@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -43,6 +43,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ''
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:06:34 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_the_is_active_and_id_token_fields.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_the_is_active_and_id_token_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://mobileteste269%40mailinator.com:vivalasvegas@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -76,6 +76,6 @@ http_interactions:
         j4gcT3d+yKZjwccxsW6vLGJtuu4Y2jcwDNx4oq+18hX33muWwCxOZu7Obnh7
         u3vcqsudbBf79GF9tYnl88tNZm5F2K7feXvdXOyGpif3ct8sxNPGE2MHND3f
         mYpaZHSMiSjOfZs0sLGLkcUre2vUqPifsL7Nxr8/AbiMY75MAgAA
-    http_version: 
+    http_version:
   recorded_at: Mon, 10 Jun 2013 22:09:29 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_true_if_the_password_is_correct.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_authenticate/should_return_true_if_the_password_is_correct.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -70,11 +70,11 @@ http_interactions:
         vIGnPFzcyT/RVGAow24prWPsQ3vCYaJpaPt4O17c0p8NWJPbrEVr4HDGw0Um
         C+1wd+HpKeAU2xm5fZ7lr0x5QsxxXGfJfwzHu7m6+nI8fotxoNe0xp7McHmY
         PrdzFhcV8Ih5yWUib+LPy/Mnkqoe/gX4cNFa0AwAAA==
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:04:08 GMT
 - request:
     method: get
-    uri: http://teste%40teste.com:123456@sandbox.app.passaporteweb.com.br/accounts/api/auth/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/auth/
     body:
       encoding: US-ASCII
       string: ''
@@ -130,6 +130,6 @@ http_interactions:
         lsIC/Q2jQO/DqlGTZe71HoIwBs34GRdhpER9UdzirdxywLsEu4WTiTaMl0ba
         9yCoC7JOwf0P5YxIGG+L5JdhGG1ANH4YrjF2eYzhJ4yOgrzr4uLiCgegyYvk
         bPB1eu/zKXX6BlBr+M03AgAA
-    http_version: 
+    http_version:
   recorded_at: Wed, 03 Apr 2013 15:04:09 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=true&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=true&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_other_services.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_other_services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_other_services_and_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_find_the_requested_profile_by_uuid_including_other_services_and_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=true&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=true&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_raise_an_error_if_no_profiles_exist_with_that_uuid.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_raise_an_error_if_no_profiles_exist_with_that_uuid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_return_the_is_active_and_id_token_fields.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find/should_return_the_is_active_and_id_token_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/13b972ab-0946-4a5b-8217-60255a9cbee7/?include_expired_accounts=true&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/13b972ab-0946-4a5b-8217-60255a9cbee7/?include_expired_accounts=true&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=true&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=true&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_other_services.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_other_services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=false&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=false&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_other_services_and_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_find_the_requested_profile_by_email_including_other_services_and_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=true&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=teste@teste.com&include_expired_accounts=true&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid@email.com/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid@email.com/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_return_the_is_active_and_id_token_fields.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_find_by_email/should_return_the_is_active_and_id_token_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=mobileteste269@mailinator.com&include_expired_accounts=true&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/?email=mobileteste269@mailinator.com&include_expired_accounts=true&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile/should_find_the_requested_profile_by_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile/should_find_the_requested_profile_by_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/8923199e-6c43-415a-bbd1-2e302fdf8d96/profile
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/8923199e-6c43-415a-bbd1-2e302fdf8d96/profile
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Mon, 05 May 2014 19:47:03 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/8923199e-6c43-415a-bbd1-2e302fdf8d96/profile/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/8923199e-6c43-415a-bbd1-2e302fdf8d96/profile/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/profile
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/profile
     body:
       encoding: US-ASCII
       string: ''
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Mon, 05 May 2014 19:57:28 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/profile/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid-uuid/profile/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
+    uri: http://sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
+    uri: http://sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_other_services.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_other_services.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
+    uri: http://sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_other_services_and_expired_accounts.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_find_the_requested_profile_by_email_including_other_services_and_expired_accounts.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
+    uri: http://sandbox.app.passaporteweb.com.br/profile/api/info/?email=teste@teste.com
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_raise_an_error_if_no_profiles_exist_with_that_email.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid@email.com/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/invalid@email.com/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_return_the_is_active_and_id_token_fields.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_profile_by_email/should_return_the_is_active_and_id_token_fields.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/profile/api/info/?email=mobileteste269@mailinator.com
+    uri: http://sandbox.app.passaporteweb.com.br/profile/api/info/?email=mobileteste269@mailinator.com
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_failure/should_not_save.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_failure/should_not_save.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/create/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/create/
     body:
       encoding: UTF-8
       string: ! '{"email":"lula_luis81@example.com","first_name":"Luis Inácio","last_name":"da

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_success/should_save_with_all_params.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_success/should_save_with_all_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/create/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/create/
     body:
       encoding: UTF-8
       string: ! '{"cpf":"613.862.250-29","email":"lula_luis2006@example.com","first_name":"Luis

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_success/should_save_with_password_password2_and_must_change_password.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/POST/on_success/should_save_with_password_password2_and_must_change_password.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/create/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/create/
     body:
       encoding: UTF-8
       string: ! '{"email":"lula_luis2002@example.com","first_name":"Luis Inácio","last_name":"da

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/PUT/on_failure/should_return_false_and_set_the_errors_hash.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/PUT/on_failure/should_return_false_and_set_the_errors_hash.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -90,7 +90,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 17:28:16 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: UTF-8
       string: ! '{"cpf":42,"first_name":"Testador 2","gender":"","last_name":"","nickname":"","send_myfreecomm_news":false,"send_partner_news":false}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/PUT/on_success/should_update_the_profile_attributes_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Identity/_save/PUT/on_success/should_update_the_profile_attributes_on_the_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -90,7 +90,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 17:28:12 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: UTF-8
       string: ! '{"first_name":"Testador 2","gender":"","last_name":"","nickname":"","send_myfreecomm_news":false,"send_partner_news":false}'
@@ -161,7 +161,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 17:28:14 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_find/should_find_the_IdentityService_representing_the_existing_relationship_between_the_Identity_and_the_Service.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_find/should_find_the_IdentityService_representing_the_existing_relationship_between_the_Identity_and_the_Service.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:07:24 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_find/should_return_nil_it_the_Identity_does_not_have_a_relationship_with_the_Service.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_find/should_return_nil_it_the_Identity_does_not_have_a_relationship_with_the_Service.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/840df3bd-8414-4085-9920-1937f4b37dd3/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/840df3bd-8414-4085-9920-1937f4b37dd3/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -64,7 +64,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:12:17 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_save/should_create_the_relationship_between_Identity_and_Service_with_extra_data.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_save/should_create_the_relationship_between_Identity_and_Service_with_extra_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/840df3bd-8414-4085-9920-1937f4b37dd3/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/840df3bd-8414-4085-9920-1937f4b37dd3/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -81,7 +81,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:47:33 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
     body:
       encoding: UTF-8
       string: ! '{"is_active":true,"service_data":{"foo":"bar","spam":"eggs","integer":2,"float":3.456,"array":[1,2.0,"three","four"],"hash":{"oba":"eba"}}}'
@@ -136,7 +136,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:47:38 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/840df3bd-8414-4085-9920-1937f4b37dd3/identity_client/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_save/should_update_the_relationship_between_Identity_and_Service_with_extra_data.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityService/_save/should_update_the_relationship_between_Identity_and_Service_with_extra_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -89,7 +89,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:44:23 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:44:23 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
     body:
       encoding: UTF-8
       string: ! '{"is_active":true,"service_data":{"foo":"bar","spam":"eggs","integer":2,"float":3.456,"array":[1,2.0,"three","four"],"hash":{"oba":"eba"}}}'
@@ -195,7 +195,7 @@ http_interactions:
   recorded_at: Thu, 18 Apr 2013 18:44:24 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/service-info/5e32f927-c4ab-404e-a91c-b2abc05afb56/identity_client/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_find_all_service_accounts_the_identity_is_associted_to_in_the_current_authenticated_application.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_find_all_service_accounts_the_identity_is_associted_to_in_the_current_authenticated_application.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -71,7 +71,7 @@ http_interactions:
   recorded_at: Tue, 06 Aug 2013 21:00:30 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_find_only_service_accounts_in_which_the_identity_has_the_supplied_role.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_find_only_service_accounts_in_which_the_identity_has_the_supplied_role.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -71,7 +71,7 @@ http_interactions:
   recorded_at: Tue, 06 Aug 2013 21:00:32 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=false&role=foo,bar
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=false&role=foo,bar
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_include_expired_service_accounts_if_asked_to.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_include_expired_service_accounts_if_asked_to.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -71,7 +71,7 @@ http_interactions:
   recorded_at: Tue, 06 Aug 2013 21:00:31 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=true&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=true&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_include_other_services_is_asked_to.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_find_all/should_include_other_services_is_asked_to.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -71,7 +71,7 @@ http_interactions:
   recorded_at: Tue, 06 Aug 2013 20:59:50 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=true
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&include_other_services=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_new/should_instanciate_a_new_object_with_attributes_set.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_new/should_instanciate_a_new_object_with_attributes_set.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_failure/should_return_false_and_populate_errors_with_the_failure_reasons.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_failure/should_return_false_and_populate_errors_with_the_failure_reasons.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Wed, 03 Apr 2013 03:54:06 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
     body:
       encoding: UTF-8
       string: ! '{"plan_slug":"basic","expiration":"2013-03-19","name":"Conta Nova

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_success/should_create_a_new_service_account_by_name_for_the_identity_in_the_current_authenticated_application.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_success/should_create_a_new_service_account_by_name_for_the_identity_in_the_current_authenticated_application.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -79,7 +79,7 @@ http_interactions:
   recorded_at: Wed, 03 Apr 2013 03:51:07 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
     body:
       encoding: UTF-8
       string: ! '{"plan_slug":"basic","expiration":"2013-04-18","name":"Conta Nova

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_success/should_create_a_new_service_account_by_uuid_for_the_identity_in_the_current_authenticated_application.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_IdentityServiceAccount/_save/on_success/should_create_a_new_service_account_by_uuid_for_the_identity_in_the_current_authenticated_application.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -66,7 +66,7 @@ http_interactions:
   recorded_at: Wed, 10 Jun 2015 18:39:08 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
     body:
       encoding: UTF-8
       string: '{"plan_slug":"basic","expiration":"2015-06-25","uuid":"92d52d25-c7a6-4d16-ae9e-c5f2b4f8fa43"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_failure/it_should_return_an_error_message_if_an_invalid_parameter_is_sent.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_failure/it_should_return_an_error_message_if_an_invalid_parameter_is_sent.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=false&since=lalala
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=false&since=lalala
     body:
       encoding: US-ASCII
       string: ''
@@ -41,6 +41,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"since": ["Informe uma data/hora v\u00e1lida."]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 02:54:19 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_success/should_return_count_of_notifications_for_the_authenticated_user.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_success/should_return_count_of_notifications_for_the_authenticated_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=false
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=false
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"count": 2, "destination": "385f5f3c-8d33-4b95-9e0d-e87962985244"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 02:54:19 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_success/should_return_count_of_notifications_for_the_authenticated_user_according_to_params.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_count/on_success/should_return_count_of_notifications_for_the_authenticated_user_according_to_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=true&since=2013-04-02
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/count/?show_read=true&since=2013-04-02
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"count": 2, "destination": "385f5f3c-8d33-4b95-9e0d-e87962985244"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 02:54:19 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_destroy_the_notification_on_PassaporteWeb_if_the_notification_has_not_been_read_and_is_scheduled.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_destroy_the_notification_on_PassaporteWeb_if_the_notification_has_not_been_read_and_is_scheduled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"novinha","scheduled_to":"2013-04-06","destination":"a5868d14-6529-477a-9c6b-a09dd42a7cd2"}'
@@ -58,7 +58,7 @@ http_interactions:
   recorded_at: Thu, 04 Apr 2013 18:32:23 GMT
 - request:
     method: delete
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/3ffbc1cf-5a34-4ace-a6a4-47ae02db6338/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/3ffbc1cf-5a34-4ace-a6a4-47ae02db6338/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_not_exclude_already_read_notification.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_not_exclude_already_read_notification.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"novinha","scheduled_to":"2013-04-06","destination":"a5868d14-6529-477a-9c6b-a09dd42a7cd2"}'
@@ -118,7 +118,7 @@ http_interactions:
   recorded_at: Thu, 04 Apr 2013 18:32:24 GMT
 - request:
     method: delete
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/6653771d-fa75-4766-a31b-3c8a3b8c328a/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/6653771d-fa75-4766-a31b-3c8a3b8c328a/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_not_exclude_non-scheduled_notification.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_destroy/should_not_exclude_non-scheduled_notification.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"novinha","destination":"a5868d14-6529-477a-9c6b-a09dd42a7cd2"}'
@@ -58,7 +58,7 @@ http_interactions:
   recorded_at: Thu, 04 Apr 2013 18:32:25 GMT
 - request:
     method: delete
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/649fdd61-9dab-4bad-80c8-c58de9037b97/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/649fdd61-9dab-4bad-80c8-c58de9037b97/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_failure/400_Bad_Request.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_failure/400_Bad_Request.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=lalala&page=1&show_read=true
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=lalala&page=1&show_read=true
     body:
       encoding: US-ASCII
       string: ''
@@ -42,6 +42,6 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"ordering": ["Fa\u00e7a uma escolha v\u00e1lida. lalala n\u00e3o
         est\u00e1 dispon\u00edvel."]}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 02:47:37 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_failure/404_Not_Found.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_failure/404_Not_Found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1000000&show_read=false
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1000000&show_read=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_success/should_return_notifications_for_the_authenticated_user_according_to_params_along_with_pagination_information.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_success/should_return_notifications_for_the_authenticated_user_according_to_params_along_with_pagination_information.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=1&ordering=newest-first&page=2&show_read=true
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=1&ordering=newest-first&page=2&show_read=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_success/should_return_the_first_20_notifications_for_the_authenticated_user_along_with_pagination_information.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_find_all/on_success/should_return_the_first_20_notifications_for_the_authenticated_user_along_with_pagination_information.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_read_/on_failure/should_return_false_if_the_notification_is_already_read.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_read_/on_failure/should_return_false_if_the_notification_is_already_read.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:3e4470e59d76f748e0081b514da62ed621a893c87facd4a6@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=true
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=true
     body:
       encoding: US-ASCII
       string: ''
@@ -91,6 +91,6 @@ http_interactions:
         UNXJmkoJjFbeWIqOO9DANYLZyHCL1BWGZ6vLRlUvVr8vw3gCkr9/zb10rzZQ
         W491vihaKisjaSWFoXWJnXGcGwmw0b0tUlfck3kQLhrF33jGPnscUkhP5K4P
         eXVhYBFejlp3PvqvmxeNpLnq5rc/k4IbaDoIAAA=
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 15:51:48 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_read_/on_success/should_mark_the_Notification_as_read.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_read_/on_success/should_mark_the_Notification_as_read.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:3e4470e59d76f748e0081b514da62ed621a893c87facd4a6@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
     body:
       encoding: US-ASCII
       string: ''
@@ -62,11 +62,11 @@ http_interactions:
         KtNZozrTWtUf6Wonra2B3QDjmkJmejmamNhf/QTsU1wbmH3zH1VTXev0TZgD
         oeNUXe1BH9XBlBG6HT71oM1eo4i0OASG0rrLCD9U62ekyJ43cQq+XHs15FtF
         /onc9IcehS0E6IALjjmEErx/7nib6YkeX7/OU2JbPQEAAA==
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 15:51:47 GMT
 - request:
     method: put
-    uri: http://:3e4470e59d76f748e0081b514da62ed621a893c87facd4a6@sandbox.app.passaporteweb.com.br/notifications/api/97a9bde9-8deb-4874-8427-93ef7c1174aa/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/97a9bde9-8deb-4874-8427-93ef7c1174aa/
     body:
       encoding: UTF-8
       string: ! '{}'
@@ -139,6 +139,6 @@ http_interactions:
         TGeN6kxrVX+ki520tgZ2A4xrCpnpz9HExP7iJ2Cf4trA7JtPVE11rdONMAdC
         x6m62oM+qoMpT+h2OOlBmz1GEWlxCAwldZcRfqjGv5Eie97EOfjS7dGQrxX5
         F3LTEz0KWwjQAb9dZGz9/f8Ux9tct8QcwuMXFAiDukwBAAA=
-    http_version: 
+    http_version:
   recorded_at: Thu, 04 Apr 2013 15:51:48 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_an_do_nothing_if_the_Notification_is_already_persisted.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_an_do_nothing_if_the_Notification_is_already_persisted.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=true
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=true
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_and_set_the_errors_with_the_reason_for_the_failure_authenticated_as_the_application.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_and_set_the_errors_with_the_reason_for_the_failure_authenticated_as_the_application.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"feliz aniversário!","target_url":"http://pittlandia.net","scheduled_to":"2013-04-19

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_and_set_the_errors_with_the_reason_for_the_failure_authenticated_as_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_failure/should_return_false_and_set_the_errors_with_the_reason_for_the_failure_authenticated_as_the_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"feliz aniversário!","target_url":"lalalala","scheduled_to":"2013-04-19

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_success/should_create_the_Notification_on_PassaporteWeb_authenticated_as_the_application.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_success/should_create_the_Notification_on_PassaporteWeb_authenticated_as_the_application.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"feliz aniversário!","target_url":"http://pittlandia.net","scheduled_to":"2013-04-19

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_success/should_create_the_Notification_on_PassaporteWeb_authenticated_as_the_user.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_create/on_success/should_create_the_Notification_on_PassaporteWeb_authenticated_as_the_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/
     body:
       encoding: UTF-8
       string: ! '{"body":"feliz aniversário!","target_url":"http://pittlandia.net","scheduled_to":"2013-04-19

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_update/on_success/should_mark_the_Notification_as_read.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_Notification/_save/on_update/on_success/should_mark_the_Notification_as_read.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/?limit=20&ordering=oldest-first&page=1&show_read=false
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +77,7 @@ http_interactions:
   recorded_at: Thu, 04 Apr 2013 03:37:21 GMT
 - request:
     method: put
-    uri: http://:f01d30c0a2e878fecc838735560253f9e9395932f5337f40@sandbox.app.passaporteweb.com.br/notifications/api/2ca046be-0178-418d-80ac-3a334c264009/
+    uri: http://sandbox.app.passaporteweb.com.br/notifications/api/2ca046be-0178-418d-80ac-3a334c264009/
     body:
       encoding: UTF-8
       string: ! '{}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_failure/when_given_wrong_identity/assigns_errors.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_failure/when_given_wrong_identity/assigns_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/bc4bb967-e5b2-4925-813c-4d1e5418247a/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/bc4bb967-e5b2-4925-813c-4d1e5418247a/
     body:
       encoding: US-ASCII
       string: ''
@@ -57,7 +57,7 @@ http_interactions:
   recorded_at: Thu, 11 Jun 2015 14:42:46 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/activate/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/activate/
     body:
       encoding: UTF-8
       string: '{"slug":"basic","identity":"wrong-idendity","global_account":"bc4bb967-e5b2-4925-813c-4d1e5418247a"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_failure/when_given_wrong_identity/returns_false.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_failure/when_given_wrong_identity/returns_false.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/bc4bb967-e5b2-4925-813c-4d1e5418247a/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/bc4bb967-e5b2-4925-813c-4d1e5418247a/
     body:
       encoding: US-ASCII
       string: ''
@@ -57,7 +57,7 @@ http_interactions:
   recorded_at: Thu, 11 Jun 2015 14:42:44 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/activate/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/activate/
     body:
       encoding: UTF-8
       string: '{"slug":"basic","identity":"wrong-idendity","global_account":"bc4bb967-e5b2-4925-813c-4d1e5418247a"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_success/activates_the_service_account_an_returns_true.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_success/activates_the_service_account_an_returns_true.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/019a3450-8107-4832-8321-de4e6580c06b/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/019a3450-8107-4832-8321-de4e6580c06b/
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +58,7 @@ http_interactions:
   recorded_at: Thu, 11 Jun 2015 14:52:58 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/activate/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/activate/
     body:
       encoding: UTF-8
       string: '{"slug":"basic","identity":"20a8bbe1-3b4a-4e46-a69a-a7c524bd2ab8","global_account":"019a3450-8107-4832-8321-de4e6580c06b"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_success/assigns_no_errors.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_activate/on_success/assigns_no_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/019a3450-8107-4832-8321-de4e6580c06b/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/019a3450-8107-4832-8321-de4e6580c06b/
     body:
       encoding: US-ASCII
       string: ''
@@ -58,7 +58,7 @@ http_interactions:
   recorded_at: Thu, 11 Jun 2015 14:52:59 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/activate/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/activate/
     body:
       encoding: UTF-8
       string: '{"slug":"basic","identity":"20a8bbe1-3b4a-4e46-a69a-a7c524bd2ab8","global_account":"019a3450-8107-4832-8321-de4e6580c06b"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find/on_failure/should_raise_an_error_if_no_Account_exist_with_that_uuid.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find/on_failure/should_raise_an_error_if_no_Account_exist_with_that_uuid.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312062/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312062/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find/on_success/should_return_an_instance_of_Account_with_all_the_details.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find/on_success/should_return_an_instance_of_Account_with_all_the_details.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_find_all_accounts_related_to_the_authenticated_application_and_return_them_as_an_array_of_Account_instances.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_find_all_accounts_related_to_the_authenticated_application_and_return_them_as_an_array_of_Account_instances.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=20&page=1
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=20&page=1
     body:
       encoding: US-ASCII
       string: ''
@@ -100,6 +100,6 @@ http_interactions:
         c3g25oc6H4d/ZiIvq6O0nCwvHLkqCYtC7tdjdz68Bl6NnCm5bozRM4Bns4tI
         SkMmj4BZ5aGVFzC8GeBKySeR2cKfuVdJeB08zuYF74/Un65e7qgIf8rLHWOM
         bX7c/ANodCP4EyUAAA==
-    http_version: 
+    http_version:
   recorded_at: Thu, 28 Mar 2013 21:15:31 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_raise_an_error_if_the_page_does_not_exist.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_raise_an_error_if_the_page_does_not_exist.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=20&page=4000000
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=20&page=4000000
     body:
       encoding: US-ASCII
       string: ''
@@ -45,6 +45,6 @@ http_interactions:
     body:
       encoding: US-ASCII
       string: ! '{"detail": "That page contains no results"}'
-    http_version: 
+    http_version:
   recorded_at: Thu, 28 Mar 2013 21:15:33 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_return_information_about_all_possible_pages.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_find_all/should_return_information_about_all_possible_pages.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=3&page=3
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/?limit=3&page=3
     body:
       encoding: US-ASCII
       string: ''
@@ -88,6 +88,6 @@ http_interactions:
         mPa4gIvvM/n/M19KNaLhBkHXJEHo3IAUNYKkSheS55oX8sr5WhThKvjiXwFb
         MvYfAPvVQn8AbMAYcejDSFtScEwIYVK7S1JXlWgU5QoMVzWIquCAJAwIbrrq
         Vs9fQRdXTt2iCFdBXfGVuiVj/4G6Xy2UHdYfWyOyhjcHAAA=
-    http_version: 
+    http_version:
   recorded_at: Thu, 28 Mar 2013 21:15:32 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_list_accounts_user/on_success/should_listed_and_return_hash_with_data_of_account_user.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_list_accounts_user/on_success/should_listed_and_return_hash_with_data_of_account_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&role=
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/?include_expired_accounts=false&role=
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_new_account_user/POST/on_failure/should_false_with_membership_data.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_new_account_user/POST/on_failure/should_false_with_membership_data.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/859d3542-84d6-4909-b1bd-4f43c1312065/accounts/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/859d3542-84d6-4909-b1bd-4f43c1312065/accounts/
     body:
       encoding: UTF-8
       string: ! '{"plan_slug":"passaporteweb-client-ruby","uuid_user":"a5868d14-6529-477a-9c6b-a09dd42a7cd2"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_new_account_user/POST/on_success/should_save_the_members_in_account.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_new_account_user/POST/on_success/should_save_the_members_in_account.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/accounts/
     body:
       encoding: UTF-8
       string: ! '{"plan_slug":"passaporteweb-client-ruby","name":"ContaPessoal5"}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_save/on_failure/should_return_false_and_set_the_errors_hash.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_save/on_failure/should_return_false_and_set_the_errors_hash.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Mon, 01 Apr 2013 21:51:25 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: UTF-8
       string: ! '{}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_save/on_success/should_update_the_ServiceAccount_attributes_on_the_server.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_save/on_success/should_update_the_ServiceAccount_attributes_on_the_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Mon, 01 Apr 2013 21:51:24 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: UTF-8
       string: ! '{"plan_slug":"basic","expiration":"2014-05-01"}'
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Mon, 01 Apr 2013 21:51:25 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_uuid/should_return_the_uuid_of_the_ServiceAccount.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccount/_uuid/should_return_the_uuid_of_the_ServiceAccount.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_destroy/should_destroy_the_membership_removing_the_association_between_service_account_and_identity.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_destroy/should_destroy_the_membership_removing_the_association_between_service_account_and_identity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:26:47 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -151,7 +151,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:26:48 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:26:49 GMT
 - request:
     method: delete
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -261,7 +261,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:26:49 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_destroy/should_return_false_if_the_role_is_owner.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_destroy/should_return_false_if_the_role_is_owner.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:54:34 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -151,7 +151,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:54:35 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -209,7 +209,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:54:35 GMT
 - request:
     method: delete
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -256,7 +256,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:54:35 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_find/should_raise_an_404_error_if_the_membership_does_not_exist.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_find/should_raise_an_404_error_if_the_membership_does_not_exist.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:17:50 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/identity-uuid/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/identity-uuid/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_find/should_return_an_instance_of_ServiceAccountMember_with_all_attributes_set.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_find/should_return_an_instance_of_ServiceAccountMember_with_all_attributes_set.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:17:49 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -168,7 +168,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:17:50 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_failure/should_not_create_the_membership_and_set_the_errors_on_the_object.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_failure/should_not_create_the_membership_and_set_the_errors_on_the_object.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -79,7 +79,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:35:49 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -165,7 +165,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:35:50 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
     body:
       encoding: UTF-8
       string: ! '{"identity":"5e32f927-c4ab-404e-a91c-b2abc05afb56","roles":["owner"]}'
@@ -214,7 +214,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:35:51 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_failure/should_return_false_if_the_membership_already_exists.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_failure/should_return_false_if_the_membership_already_exists.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:39:22 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:39:23 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
     body:
       encoding: UTF-8
       string: ! '{"identity":"5e32f927-c4ab-404e-a91c-b2abc05afb56","roles":["admin","user"]}'
@@ -184,7 +184,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:39:24 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_success/should_create_the_membership_between_the_service_account_and_the_identity.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_creating/on_success/should_create_the_membership_between_the_service_account_and_the_identity.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -62,7 +62,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:32:55 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -131,7 +131,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:32:57 GMT
 - request:
     method: post
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/
     body:
       encoding: UTF-8
       string: ! '{"identity":"5e32f927-c4ab-404e-a91c-b2abc05afb56","roles":["admin","user"]}'
@@ -210,7 +210,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:32:58 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_updating/on_failure/should_return_false_and_set_the_errors.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_updating/on_failure/should_return_false_and_set_the_errors.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -63,7 +63,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:50:34 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:50:35 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -193,7 +193,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:50:35 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: UTF-8
       string: ! '{"roles":["owner"]}'

--- a/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_updating/on_success/should_update_the_member_roles.yml
+++ b/spec/fixtures/vcr_cassettes/PassaporteWeb_ServiceAccountMember/_save/when_updating/on_success/should_update_the_member_roles.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/
     body:
       encoding: US-ASCII
       string: ''
@@ -80,7 +80,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:46:38 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
+    uri: http://sandbox.app.passaporteweb.com.br/accounts/api/identities/5e32f927-c4ab-404e-a91c-b2abc05afb56/?include_expired_accounts=false&include_other_services=false
     body:
       encoding: US-ASCII
       string: ''
@@ -151,7 +151,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:46:39 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''
@@ -227,7 +227,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:46:39 GMT
 - request:
     method: put
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: UTF-8
       string: ! '{"roles":["user"]}'
@@ -304,7 +304,7 @@ http_interactions:
   recorded_at: Tue, 02 Apr 2013 15:46:40 GMT
 - request:
     method: get
-    uri: http://8ab29iwKFI:VnWYenOqYsHtcFowrdJlwdJNALq5Go9v@sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
+    uri: http://sandbox.app.passaporteweb.com.br/organizations/api/accounts/859d3542-84d6-4909-b1bd-4f43c1312065/members/5e32f927-c4ab-404e-a91c-b2abc05afb56/
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/passaporte_web/identity_spec.rb
+++ b/spec/passaporte_web/identity_spec.rb
@@ -134,7 +134,7 @@ describe PassaporteWeb::Identity do
     it "should raise an error if no profiles exist with that uuid" do
       expect {
         described_class.find("invalid-uuid")
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
   end
 
@@ -181,7 +181,7 @@ describe PassaporteWeb::Identity do
     it "should raise an error if no profiles exist with that email" do
       expect {
         described_class.find("invalid@email.com")
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
   end
 
@@ -215,7 +215,7 @@ describe PassaporteWeb::Identity do
     it "should raise an error if no profiles exist with that email" do
       expect {
         described_class.profile("invalid-uuid")
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
   end
 
@@ -240,7 +240,7 @@ describe PassaporteWeb::Identity do
     it "should raise an error if no profiles exist with that email" do
       expect do
         described_class.find("invalid@email.com")
-      end.to raise_error(RestClient::ResourceNotFound, "404 Resource Not Found")
+      end.to raise_error(RestClient::ResourceNotFound)
     end
   end
 

--- a/spec/passaporte_web/notification_spec.rb
+++ b/spec/passaporte_web/notification_spec.rb
@@ -94,7 +94,7 @@ describe PassaporteWeb::Notification do
       it "404 Not Found" do
         expect {
           PassaporteWeb::Notification.find_all(1_000_000)
-        }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+        }.to raise_error(RestClient::ResourceNotFound)
       end
     end
   end

--- a/spec/passaporte_web/service_account_member_spec.rb
+++ b/spec/passaporte_web/service_account_member_spec.rb
@@ -39,7 +39,7 @@ describe PassaporteWeb::ServiceAccountMember do
     it "should raise an 404 error if the membership does not exist" do
       expect {
         described_class.find(service_account, double('Identity', uuid: 'identity-uuid'))
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
   end
 
@@ -52,7 +52,7 @@ describe PassaporteWeb::ServiceAccountMember do
       expect(member.errors).to be_empty
       expect {
         described_class.find(service_account, identity)
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
     it "should return false if the role is owner" do
       member = described_class.find(service_account, identity)
@@ -102,7 +102,7 @@ describe PassaporteWeb::ServiceAccountMember do
 
           expect {
             described_class.find(service_account, identity)
-          }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+          }.to raise_error(RestClient::ResourceNotFound)
         end
         it "should return false if the membership already exists" do
           expect(member.save).to be_falsy

--- a/spec/passaporte_web/service_account_spec.rb
+++ b/spec/passaporte_web/service_account_spec.rb
@@ -81,7 +81,7 @@ describe PassaporteWeb::ServiceAccount do
     it "should raise an error if the page does not exist" do
       expect {
         PassaporteWeb::ServiceAccount.find_all(4_000_000)
-      }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+      }.to raise_error(RestClient::ResourceNotFound)
     end
   end
 
@@ -107,7 +107,7 @@ describe PassaporteWeb::ServiceAccount do
       it "should raise an error if no Account exist with that uuid" do
         expect {
           PassaporteWeb::ServiceAccount.find("859d3542-84d6-4909-b1bd-4f43c1312062")
-        }.to raise_error(RestClient::ResourceNotFound, '404 Resource Not Found')
+        }.to raise_error(RestClient::ResourceNotFound)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ require 'passaporte_web'
 
 require 'vcr'
 require 'pry'
+require 'webmock/rspec'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'


### PR DESCRIPTION
## Co-Author: @eduardohertz 

`KeyError: key not found: :ciphers.`

**This will address issues:**

1. https://github.com/rest-client/rest-client/issues/569
2. https://github.com/ruby/openssl/pull/66

- Upgrade to openssl 1.0.2n for security reasons;
- New openssl versions won't work with old rest-client;
- Upgrade rest-client to 2.0.2;
- rest-client upgrade will mess webmock;
- Upgrade webmock to 3.1.1 to support Ruby 2.4.2;
- Fix spec errors in test environment;
- Fix license name typo;

**squashed commits**

> Upgrade rest-client
> 
> Regarding this issue: https://github.com/rest-client/rest-client/issues/569
> 
> Fix typo in license name
> 
> Regarding:
> WARNING:  license value 'Apache-v2' is invalid.  Use a license identifier from
> http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
> Did you mean 'Apache-1.0', 'Apache-1.1', 'Apache-2.0'?
> 
> Fix VCR request fixtures
> 
> Use new fixtures during test
> 
> Upgrade webmock gem